### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Web/App/Ballet.pm6
+++ b/lib/Web/App/Ballet.pm6
@@ -1,6 +1,6 @@
 use Web::App::Dispatch;
 
-module Web::App::Ballet;
+unit module Web::App::Ballet;
 
 my $app-transport;
 my $app-object;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.